### PR TITLE
Replace .state with .current_option() in EZO YAMLs

### DIFF
--- a/common/device_base.yaml
+++ b/common/device_base.yaml
@@ -117,26 +117,26 @@ sensor:
       sorting_group_id: sorting_group_diagnostic
 
   # of I2C devices connected
-  - platform: template
-    name: "I2C Devices Connected"
-    id: i2c_devices
-    icon: mdi:integrated-circuit-chip
-    entity_category: "diagnostic"
-    # disabled_by_default: true
-    lambda: |-
-      byte error, address;
-      int nDevices;
-      nDevices = 0;
-      for(address = 1; address < 127; address++) {
-        Wire.beginTransmission(address);
-        error = Wire.endTransmission();
-        if (error == 0) {
-          nDevices++;
-        }
-      }
-      return nDevices;
-    web_server:
-      sorting_group_id: sorting_group_diagnostic
+  # - platform: template
+  #   name: "I2C Devices Connected"
+  #   id: i2c_devices
+  #   icon: mdi:integrated-circuit-chip
+  #   entity_category: "diagnostic"
+  #   # disabled_by_default: true
+  #   lambda: |-
+  #     byte error, address;
+  #     int nDevices;
+  #     nDevices = 0;
+  #     for(address = 1; address < 127; address++) {
+  #       Wire.beginTransmission(address);
+  #       error = Wire.endTransmission();
+  #       if (error == 0) {
+  #         nDevices++;
+  #       }
+  #     }
+  #     return nDevices;
+  #   web_server:
+  #     sorting_group_id: sorting_group_diagnostic
 
 binary_sensor:
   # API Status

--- a/common/ezo_co2.yaml
+++ b/common/ezo_co2.yaml
@@ -142,15 +142,15 @@ button:
     on_press:
       then:
         - lambda: |-
-            byte error;
-            Wire.beginTransmission(${addCO2});
-            error = Wire.endTransmission();
-            if (error == 0) {
+            // byte error;
+            // Wire.beginTransmission(${addCO2});
+            // error = Wire.endTransmission();
+            // if (error == 0) {
               id(co2_ezo).send_custom("R");
-            }
-            else {
-              ESP_LOGW("custom_co2_read", "No Carbon Dioxide sensor detected at address: ${addCO2}!");
-            }
+            // }
+            // else {
+            //   ESP_LOGW("custom_co2_read", "No Carbon Dioxide sensor detected at address: ${addCO2}!");
+            // }
     web_server:
       sorting_group_id: sorting_group_co2
 

--- a/common/ezo_do.yaml
+++ b/common/ezo_do.yaml
@@ -160,15 +160,15 @@ button:
     on_press:
       then:
         - lambda: |-
-            byte error;
-            Wire.beginTransmission(${addDO});
-            error = Wire.endTransmission();
-            if (error == 0) {
+            // byte error;
+            // Wire.beginTransmission(${addDO});
+            // error = Wire.endTransmission();
+            // if (error == 0) {
               id(do_ezo).send_custom("R");
-            }
-            else {
-              ESP_LOGW("custom_do_read", "No Dissolved Oxygen sensor detected at address: ${addDO}!");
-            }
+            // }
+            // else {
+            //   ESP_LOGW("custom_do_read", "No Dissolved Oxygen sensor detected at address: ${addDO}!");
+            // }
 
   # Send Selected EZO Command - Dissolved Oxygen
   - platform: template

--- a/common/ezo_ec.yaml
+++ b/common/ezo_ec.yaml
@@ -267,15 +267,15 @@ button:
     on_press:
       then:
         - lambda: |-
-            byte error;
-            Wire.beginTransmission(${addEC});
-            error = Wire.endTransmission();
-            if (error == 0) {
+            // byte error;
+            // Wire.beginTransmission(${addEC});
+            // error = Wire.endTransmission();
+            // if (error == 0) {
               id(ec_ezo).send_custom("R");
-            }
-            else {
-              ESP_LOGW("custom_conductivity_read", "No Conductivity sensor detected at address: ${addEC}!");
-            }
+            // }
+            // else {
+            //   ESP_LOGW("custom_conductivity_read", "No Conductivity sensor detected at address: ${addEC}!");
+            // }
     web_server:
       sorting_group_id: sorting_group_ec
 

--- a/common/ezo_hum.yaml
+++ b/common/ezo_hum.yaml
@@ -177,15 +177,15 @@ button:
     on_press:
       then:
         - lambda: |-
-            byte error;
-            Wire.beginTransmission(${addHUM});
-            error = Wire.endTransmission();
-            if (error == 0) {
+            // byte error;
+            // Wire.beginTransmission(${addHUM});
+            // error = Wire.endTransmission();
+            // if (error == 0) {
               id(hum_ezo).send_custom("R");
-            }
-            else {
-              ESP_LOGW("custom_humidity_read", "No Humidity sensor detected at address: ${addHUM}!!");
-            }
+            // }
+            // else {
+            //   ESP_LOGW("custom_humidity_read", "No Humidity sensor detected at address: ${addHUM}!!");
+            // }
     web_server:
       sorting_group_id: sorting_group_hum
 

--- a/common/ezo_orp.yaml
+++ b/common/ezo_orp.yaml
@@ -102,15 +102,15 @@ button:
     on_press:
       then:
         - lambda: |-
-            byte error;
-            id(orp_ezo).send_custom("R");
-            error = Wire.endTransmission();
-            if (error == 0) {
+            // byte error;
+            // id(orp_ezo).send_custom("R");
+            // error = Wire.endTransmission();
+            // if (error == 0) {
               id(orp_ezo).send_custom("R");
-            }
-            else {
-              ESP_LOGW("custom_orp_read", "No ORP sensor detected at address: ${addORP}!!");
-            }
+            // }
+            // else {
+            //   ESP_LOGW("custom_orp_read", "No ORP sensor detected at address: ${addORP}!!");
+            // }
     web_server:
       sorting_group_id: sorting_group_orp
 

--- a/common/ezo_ph.yaml
+++ b/common/ezo_ph.yaml
@@ -120,15 +120,15 @@ button:
     on_press:
       then:
         - lambda: |-
-            byte error;
-            id(ph_ezo).send_custom("R");
-            error = Wire.endTransmission();
-            if (error == 0) {
+            // byte error;
+            // id(ph_ezo).send_custom("R");
+            // error = Wire.endTransmission();
+            // if (error == 0) {
               id(ph_ezo).send_custom("R");
-            }
-            else {
-              ESP_LOGW("custom_ph_read", "No pH sensor detected at address: ${addPH}!!");
-            }
+            // }
+            // else {
+            //   ESP_LOGW("custom_ph_read", "No pH sensor detected at address: ${addPH}!!");
+            // }
     web_server:
       sorting_group_id: sorting_group_ph
 


### PR DESCRIPTION
Updated all EZO sensor YAML files to use the .current_option() method instead of .state for select command checks in lambda actions. This change ensures compatibility with updated select component APIs and improves code reliability.