### PR TITLE
Use 'Volume-Time' wording for pump labels

### DIFF
--- a/archive/aquapi_config copy.yaml
+++ b/archive/aquapi_config copy.yaml
@@ -1,0 +1,28 @@
+---
+substitutions:
+  # App Version
+  app_version: "26.1.0"
+
+packages:
+  device_base: !include common/device_base.yaml
+  aquapi: !include common/aquapi.yaml
+  ota_https: !include common/ota_https.yaml
+  dallas: !include common/temperature_dallas.yaml
+  water_level: !include common/water_level.yaml
+  binary: !include common/binary.yaml
+  ezo_ph: !include common/ezo_ph.yaml
+  ezo_ec: !include common/ezo_ec.yaml
+  ezo_orp: !include common/ezo_orp.yaml
+  ezo_co2: !include common/ezo_co2.yaml
+  ezo_do: !include common/ezo_do.yaml
+  ezo_pmp: !include common/ezo_pmp.yaml
+  ezo_pmp_duo: !include common/ezo_pmp_duo.yaml
+  # ir_receiver: !include common/ir_receiver.yaml
+  # dht: !include common/dht.yaml
+  # binary_input: !include common/binary_input.yaml
+  # ezo_hum: !include common/ezo_hum.yaml
+  # ezo_rtd: !include common/ezo_rtd.yaml
+  # ezo_pmp_extra: !include common/ezo_pmp_extra.yaml
+  # dac: !include common/dac.yaml
+  # ezo_commands: !include common/ezo_commands.yaml
+  # debug: !include common/debug.yaml

--- a/common/ezo_pmp.yaml
+++ b/common/ezo_pmp.yaml
@@ -117,7 +117,7 @@ sensor:
     id: ezo_pump_white
     max_flow_rate:
       id: max_flow_rate
-      name: Pump White - Max Volume/Time Flow Rate
+      name: Pump White - Max Volume-Time Flow Rate
       icon: mdi:car-speed-limiter
       disabled_by_default: true
       unit_of_measurement: 'mL/min'
@@ -208,7 +208,7 @@ number:
   - platform: template
     id: flow_rate
     icon: mdi:waves-arrow-right
-    name: Pump White - Volume/Time Flow Rat
+    name: Pump White - Volume-Time Flow Rat
     disabled_by_default: true
     unit_of_measurement: 'mL/min'
     optimistic: true
@@ -258,7 +258,7 @@ button:
     web_server:
       sorting_group_id: sorting_group_pump_white
   - platform: template
-    name: Pump White - Dose at Volume/Time Flow Rate for Time
+    name: Pump White - Dose at Volume-Time Flow Rate for Time
     disabled_by_default: true
     icon: mdi:format-text-wrapping-overflow
     id: dose_flow_rate

--- a/common/ezo_pmp_blue.yaml
+++ b/common/ezo_pmp_blue.yaml
@@ -115,7 +115,7 @@ sensor:
     id: ezo_pump_blue
     max_flow_rate:
       id: max_flow_rate_blue
-      name: Pump Blue - Max Volume/Time Flow Rate
+      name: Pump Blue - Max Volume-Time Flow Rate
       icon: mdi:car-speed-limiter
       disabled_by_default: true
       unit_of_measurement: 'mL/min'
@@ -200,7 +200,7 @@ number:
   - platform: template
     id: flow_rate_blue
     icon: mdi:waves-arrow-right
-    name: Pump Blue - Volume/Time Flow Rate
+    name: Pump Blue - Volume-Time Flow Rate
     unit_of_measurement: 'mL/min'
     optimistic: true
     initial_value: 10
@@ -246,7 +246,7 @@ button:
     web_server:
       sorting_group_id: sorting_group_pump_blue
   - platform: template
-    name: Pump Blue - Dose at Volume/Time Flow Rate for Time
+    name: Pump Blue - Dose at Volume-Time Flow Rate for Time
     icon: mdi:format-text-wrapping-overflow
     id: dose_flow_rate_blue
     on_press:

--- a/common/ezo_pmp_duo.yaml
+++ b/common/ezo_pmp_duo.yaml
@@ -201,7 +201,7 @@ sensor:
     id: ezo_pump_green
     max_flow_rate:
       id: max_flow_rate_clean
-      name: Pump Clean - Max Volume/Time Flow Rate
+      name: Pump Clean - Max Volume-Time Flow Rate
       icon: mdi:car-speed-limiter
       unit_of_measurement: 'mL/min'
       disabled_by_default: true
@@ -270,7 +270,7 @@ sensor:
     id: ezo_pump_red
     max_flow_rate:
       id: max_flow_rate_waste
-      name: Pump Waste - Max Volume/Time Flow Rate
+      name: Pump Waste - Max Volume-Time Flow Rate
       icon: mdi:car-speed-limiter
       unit_of_measurement: 'mL/min'
       disabled_by_default: true
@@ -404,7 +404,7 @@ number:
   - platform: template
     id: flow_rate_clean
     icon: mdi:waves-arrow-right
-    name: Pump Clean - Volume/Time Flow Rate
+    name: Pump Clean - Volume-Time Flow Rate
     disabled_by_default: true
     unit_of_measurement: 'mL/min'
     optimistic: true
@@ -450,7 +450,7 @@ number:
   - platform: template
     id: flow_rate_waste
     icon: mdi:waves-arrow-left
-    name: Pump Waste - Volume/Time Flow Rate
+    name: Pump Waste - Volume-Time Flow Rate
     disabled_by_default: true
     unit_of_measurement: 'mL/min'
     optimistic: true
@@ -501,7 +501,7 @@ button:
     web_server:
       sorting_group_id: sorting_group_pump_green
   - platform: template
-    name: Pump Clean - Dose at Volume/Time Flow Rate for Time
+    name: Pump Clean - Dose at Volume-Time Flow Rate for Time
     disabled_by_default: true
     icon: mdi:format-text-wrapping-overflow
     id: dose_flow_rate_clean
@@ -605,7 +605,7 @@ button:
     web_server:
       sorting_group_id: sorting_group_pump_red
   - platform: template
-    name: Pump Waste - Dose at Volume/Time Flow Rate for Time
+    name: Pump Waste - Dose at Volume-Time Flow Rate for Time
     disabled_by_default: true
     icon: mdi:format-text-wrapping-overflow
     id: dose_flow_rate_waste

--- a/common/ezo_pmp_orange.yaml
+++ b/common/ezo_pmp_orange.yaml
@@ -115,7 +115,7 @@ sensor:
     id: ezo_pump_orange
     max_flow_rate:
       id: max_flow_rate_orange
-      name: Pump Orange - Max Volume/Time Flow Rate
+      name: Pump Orange - Max Volume-Time Flow Rate
       icon: mdi:car-speed-limiter
       disabled_by_default: true
       unit_of_measurement: 'mL/min'
@@ -200,7 +200,7 @@ number:
   - platform: template
     id: flow_rate_orange
     icon: mdi:waves-arrow-right
-    name: Pump Orange - Volume/Time Flow Rate
+    name: Pump Orange - Volume-Time Flow Rate
     unit_of_measurement: 'mL/min'
     optimistic: true
     initial_value: 10
@@ -246,7 +246,7 @@ button:
     web_server:
       sorting_group_id: sorting_group_pump_orange
   - platform: template
-    name: Pump Orange - Dose at Volume/Time Flow Rate for Time
+    name: Pump Orange - Dose at Volume-Time Flow Rate for Time
     icon: mdi:format-text-wrapping-overflow
     id: dose_flow_rate_orange
     on_press:

--- a/common/ezo_pmp_yellow.yaml
+++ b/common/ezo_pmp_yellow.yaml
@@ -115,7 +115,7 @@ sensor:
     id: ezo_pump_yellow
     max_flow_rate:
       id: max_flow_rate_yellow
-      name: Pump Yellow - Max Volume/Time Flow Rate
+      name: Pump Yellow - Max Volume-Time Flow Rate
       icon: mdi:car-speed-limiter
       disabled_by_default: true
       unit_of_measurement: 'mL/min'
@@ -200,7 +200,7 @@ number:
   - platform: template
     id: flow_rate_yellow
     icon: mdi:waves-arrow-right
-    name: Pump Yellow - Volume/Time Flow Rate
+    name: Pump Yellow - Volume-Time Flow Rate
     unit_of_measurement: 'mL/min'
     optimistic: true
     initial_value: 10
@@ -246,7 +246,7 @@ button:
     web_server:
       sorting_group_id: sorting_group_pump_yellow
   - platform: template
-    name: Pump Yellow - Dose at Volume/Time Flow Rate for Time
+    name: Pump Yellow - Dose at Volume-Time Flow Rate for Time
     icon: mdi:format-text-wrapping-overflow
     id: dose_flow_rate_yellow
     on_press:


### PR DESCRIPTION
Replace 'Volume/Time' with 'Volume-Time' in pump-related entity names across ezo_pmp YAMLs for consistent labeling and phrasing. Updated files: common/ezo_pmp.yaml, common/ezo_pmp_blue.yaml, common/ezo_pmp_duo.yaml, common/ezo_pmp_orange.yaml, common/ezo_pmp_yellow.yaml. Also add archive/aquapi_config copy.yaml to archive a snapshot of the Aquapi package includes and app_version.